### PR TITLE
Limiting seomoz wiith a external parameter

### DIFF
--- a/app/bots/seomoz.rb
+++ b/app/bots/seomoz.rb
@@ -6,9 +6,9 @@ require 'net/http'
 require 'uri'
 
 class Seomoz
-  def process
+  def process(limit = 100)
     return unless configured?
-    urls.each_slice(10) do |url_batch|
+    urls(limit).each_slice(10) do |url_batch|
       authority = batch(url_batch)
       if authority.first.include?('pda')
         i = 0
@@ -27,8 +27,8 @@ class Seomoz
 
   protected
 
-  def urls
-    Url.where("domain_authority = '' OR domain_authority IS NULL").limit(50)
+  def urls(limit)
+    Url.where("domain_authority = '' OR domain_authority IS NULL").limit(limit)
   end
 
   def batch(batched_domains)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,19 +61,18 @@ ActiveRecord::Schema.define(version: 20131011103057) do
   end
 
   create_table "urls", force: true do |t|
-    t.integer   "status_id"
-    t.string    "url"
-    t.timestamp "created_at",                   null: false
-    t.datetime  "updated_at"
-    t.integer   "internal_links",   default: 0
-    t.integer   "external_links",   default: 0
-    t.datetime  "visited_at"
-    t.string    "ip"
-    t.string    "subdomain"
-    t.string    "domain_authority"
-    t.string    "page_authority"
-    t.string    "source"
-    t.integer   "domain_id"
+    t.integer  "status_id"
+    t.string   "url"
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at"
+    t.integer  "internal_links",   default: 0
+    t.integer  "external_links",   default: 0
+    t.datetime "visited_at"
+    t.string   "ip"
+    t.string   "subdomain"
+    t.string   "domain_authority"
+    t.string   "page_authority"
+    t.integer  "domain_id"
   end
 
   add_index "urls", ["domain_id"], name: "index_urls_on_domain_id", using: :btree

--- a/lib/tasks/crawler.rake
+++ b/lib/tasks/crawler.rake
@@ -7,8 +7,9 @@ namespace :crawl do
   end
 
   desc 'seomoz'
-  task :seomoz => :environment do
-    Seomoz.new.process
+  task :seomoz, [:limit] => :environment do |t, args|
+    args.with_defaults(:limit => 100)
+    Seomoz.new.process args[:limit]
   end
 
   desc 'domains'


### PR DESCRIPTION
Run it with: 

```
rake "crawl:seomoz[200]" 
```
